### PR TITLE
Multiple code improvements - squid:S2293, squid:UselessParenthesesCheck, squid:S1118

### DIFF
--- a/src/main/java/com/fulmicoton/multiregexp/Lexer.java
+++ b/src/main/java/com/fulmicoton/multiregexp/Lexer.java
@@ -6,8 +6,8 @@ import java.util.Iterator;
 
 public class Lexer<T extends Enum> {
 
-    private final ArrayList<T> types = new ArrayList<T>() ;
-    private final ArrayList<String> patterns = new ArrayList<String>();
+    private final ArrayList<T> types = new ArrayList<>() ;
+    private final ArrayList<String> patterns = new ArrayList<>();
     private transient MultiPatternAutomaton automaton = null;
 
     public Lexer<T> addRule(final T tokenType, final String pattern) {
@@ -25,7 +25,7 @@ public class Lexer<T extends Enum> {
     }
 
     public Scanner<T> scannerFor(CharSequence seq) {
-        return new Scanner<T>(this.getAutomaton(), seq, this.types);
+        return new Scanner<>(this.getAutomaton(), seq, this.types);
     }
 
     public Iterable<Token<T>> scan(final CharSequence seq) {

--- a/src/main/java/com/fulmicoton/multiregexp/MultiPatternAutomaton.java
+++ b/src/main/java/com/fulmicoton/multiregexp/MultiPatternAutomaton.java
@@ -30,7 +30,7 @@ public class MultiPatternAutomaton {
         this.stride = points.length;
         this.atLeastOneAccept = new boolean[accept.length];
         for (int i=0; i<accept.length; i++) {
-            this.atLeastOneAccept[i] = (this.accept[i].length > 0);
+            this.atLeastOneAccept[i] = this.accept[i].length > 0;
         }
         this.nbPatterns = nbPatterns;
     }
@@ -120,7 +120,7 @@ public class MultiPatternAutomaton {
     }
 
     public int step(final int state, final char c) {
-        return transitions[((state * this.stride) + alphabet[c - Character.MIN_VALUE])];
+        return transitions[(state * this.stride) + alphabet[c - Character.MIN_VALUE]];
     }
 
     public int getNbPatterns() {

--- a/src/main/java/com/fulmicoton/multiregexp/Token.java
+++ b/src/main/java/com/fulmicoton/multiregexp/Token.java
@@ -11,7 +11,7 @@ public class Token<T> {
     }
 
     public static <T extends Enum> Token<T> fromScanner(Scanner<T> scanner) {
-        return new Token<T>(scanner.type, scanner.tokenString().toString());
+        return new Token<>(scanner.type, scanner.tokenString().toString());
     }
 
     @Override

--- a/src/main/java/dk/brics/automaton/DkBricsAutomatonHelper.java
+++ b/src/main/java/dk/brics/automaton/DkBricsAutomatonHelper.java
@@ -5,6 +5,8 @@ import java.util.TreeSet;
 
 public class DkBricsAutomatonHelper {
 
+    private DkBricsAutomatonHelper() {}
+
     public static char[] pointsUnion(final Iterable<Automaton> automata) {
         Set<Character> points = new TreeSet<>();
         for (Automaton automaton: automata) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S2293 - The diamond operator ("<>") should be used.
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding.
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S2293
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
George Kankava